### PR TITLE
Add session error handler to example

### DIFF
--- a/example.js
+++ b/example.js
@@ -9,9 +9,14 @@ const relay = new RelayServer({
   }
 })
 
-const server = dht.createServer((socket) => relay.accept(socket, {
-  id: socket.remotePublicKey
-}))
+const server = dht.createServer((socket) => {
+  const session = relay.accept(socket, {
+    id: socket.remotePublicKey
+  })
+
+  // For timeouts, connection reset by peer etc.
+  session.on('error', e => { console.error(e) })
+})
 
 server
   .listen()


### PR DESCRIPTION
If sessions are created without an error handler, this causes a crash in case of errors (timeouts and 'connection reset by peer' being the most common ones)

This is probably intended, but I think it's good to make it explicit by adding an error handler to the example