### PR TITLE
Expose nrSessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ exports.Server = class BlindRelayServer extends EventEmitter {
     return this._sessions[Symbol.iterator]()
   }
 
+  get nrSessions () {
+    return this._sessions.size
+  }
+
   accept (stream, opts) {
     const session = new BlindRelaySession(this, stream, opts)
 

--- a/index.js
+++ b/index.js
@@ -23,11 +23,7 @@ exports.Server = class BlindRelayServer extends EventEmitter {
   }
 
   get sessions () {
-    return this._sessions[Symbol.iterator]()
-  }
-
-  get nrSessions () {
-    return this._sessions.size
+    return this._sessions
   }
 
   accept (stream, opts) {

--- a/test.mjs
+++ b/test.mjs
@@ -63,6 +63,15 @@ test('basic', (t) => {
   }
 })
 
+test('nrSessions getter', (t) => {
+  const udx = new UDX()
+
+  const createStream = (opts) => udx.createStream(0, opts)
+  const server = withServer(t, createStream)
+
+  t.is(server.nrSessions, 0, 'can get nrSessions')
+})
+
 test('unpair after pair', (t) => {
   t.plan(2)
 

--- a/test.mjs
+++ b/test.mjs
@@ -69,7 +69,7 @@ test('sessions getter', (t) => {
   const createStream = (opts) => udx.createStream(0, opts)
   const server = withServer(t, createStream)
 
-  t.is(server.sessions, server._sessions, 'can get nrSessions')
+  t.is(server.sessions, server._sessions, 'can get sessions')
 })
 
 test('unpair after pair', (t) => {

--- a/test.mjs
+++ b/test.mjs
@@ -63,13 +63,13 @@ test('basic', (t) => {
   }
 })
 
-test('nrSessions getter', (t) => {
+test('sessions getter', (t) => {
   const udx = new UDX()
 
   const createStream = (opts) => udx.createStream(0, opts)
   const server = withServer(t, createStream)
 
-  t.is(server.nrSessions, 0, 'can get nrSessions')
+  t.is(server.sessions, server._sessions, 'can get nrSessions')
 })
 
 test('unpair after pair', (t) => {

--- a/test.mjs
+++ b/test.mjs
@@ -69,7 +69,7 @@ test('sessions getter', (t) => {
   const createStream = (opts) => udx.createStream(0, opts)
   const server = withServer(t, createStream)
 
-  t.is(server.sessions, server._sessions, 'can get sessions')
+  t.is(server.sessions.size, 0, 'can get number of sessions')
 })
 
 test('unpair after pair', (t) => {


### PR DESCRIPTION
Useful for metrics (otherwise the private prop `_sessions` needs to be accessed to get the nr of sessions)