### PR TITLE
Track active relay stats without recompute

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ exports.Server = class BlindRelayServer extends EventEmitter {
 
     this._sessions.add(session)
     this.stats.sessions.accepted++
-    this.stats.sessions.active++
 
     return session
   }
@@ -53,7 +52,6 @@ exports.Server = class BlindRelayServer extends EventEmitter {
     if (refs === 0) this.stats.pairings.active++
 
     this._activePairingRefs.set(keyString, refs + 1)
-    this.stats.streams.active++
   }
 
   _untrackActiveLink(keyString) {
@@ -67,8 +65,6 @@ exports.Server = class BlindRelayServer extends EventEmitter {
     } else {
       this._activePairingRefs.set(keyString, refs - 1)
     }
-
-    this.stats.streams.active--
   }
 }
 
@@ -152,7 +148,6 @@ class BlindRelaySession extends EventEmitter {
 
     this._server._sessions.delete(this)
     this._server.stats.sessions.closed++
-    this._server.stats.sessions.active--
 
     this.emit('close')
   }
@@ -561,7 +556,9 @@ function createStats() {
       accepted: 0,
       opened: 0,
       closed: 0,
-      active: 0
+      get active() {
+        return this.accepted - this.closed
+      }
     },
     pairings: {
       requested: 0,
@@ -574,7 +571,9 @@ function createStats() {
       opened: 0,
       closed: 0,
       errors: 0,
-      active: 0
+      get active() {
+        return this.opened - this.closed
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ exports.Server = class BlindRelayServer extends EventEmitter {
 
     this._createStream = createStream
     this._pairing = new Map()
+    this._activePairingRefs = new Map()
     this._sessions = new Set()
-    this.stats = createStats(this)
+    this.stats = createStats()
   }
 
   get sessions() {
@@ -29,6 +30,7 @@ exports.Server = class BlindRelayServer extends EventEmitter {
 
     this._sessions.add(session)
     this.stats.sessions.accepted++
+    this.stats.sessions.active++
 
     return session
   }
@@ -45,26 +47,28 @@ exports.Server = class BlindRelayServer extends EventEmitter {
     this._pairing.clear()
   }
 
-  _activePairings() {
-    const active = new Set()
+  _trackActiveLink(keyString) {
+    const refs = this._activePairingRefs.get(keyString) || 0
 
-    for (const session of this._sessions) {
-      for (const token of session._links.keys()) {
-        active.add(token)
-      }
-    }
+    if (refs === 0) this.stats.pairings.active++
 
-    return active.size
+    this._activePairingRefs.set(keyString, refs + 1)
+    this.stats.streams.active++
   }
 
-  _activeStreams() {
-    let active = 0
+  _untrackActiveLink(keyString) {
+    const refs = this._activePairingRefs.get(keyString)
 
-    for (const session of this._sessions) {
-      active += session._links.size
+    if (refs === undefined) return
+
+    if (refs === 1) {
+      this._activePairingRefs.delete(keyString)
+      this.stats.pairings.active--
+    } else {
+      this._activePairingRefs.set(keyString, refs - 1)
     }
 
-    return active
+    this.stats.streams.active--
   }
 }
 
@@ -134,7 +138,9 @@ class BlindRelaySession extends EventEmitter {
     this._server.stats.pairings.cancelled += this._pairing.size
 
     for (const token of this._pairing) {
-      this._server._pairing.delete(token.toString('hex'))
+      if (this._server._pairing.delete(token.toString('hex'))) {
+        this._server.stats.pairings.pending--
+      }
     }
 
     for (const link of this._links.values()) {
@@ -146,6 +152,7 @@ class BlindRelaySession extends EventEmitter {
 
     this._server._sessions.delete(this)
     this._server.stats.sessions.closed++
+    this._server.stats.sessions.active--
 
     this.emit('close')
   }
@@ -163,6 +170,7 @@ class BlindRelaySession extends EventEmitter {
     if (pair === undefined) {
       pair = new BlindRelayPair(token)
       this._server._pairing.set(keyString, pair)
+      this._server.stats.pairings.pending++
     } else if (pair.links[+isInitiator]) return
 
     this._pairing.add(keyString)
@@ -173,6 +181,7 @@ class BlindRelaySession extends EventEmitter {
     if (!pair.paired) return
 
     this._server._pairing.delete(keyString)
+    this._server.stats.pairings.pending--
     this._server.stats.pairings.matched++
 
     // 1st pass: Create the raw streams needed for each end of the link.
@@ -211,8 +220,10 @@ class BlindRelaySession extends EventEmitter {
         if (link) link.session._pairing.delete(keyString)
       }
 
+      this._server._pairing.delete(keyString)
+      this._server.stats.pairings.pending--
       this._server.stats.pairings.cancelled++
-      return this._server._pairing.delete(keyString)
+      return
     }
 
     const link = this._links.get(keyString)
@@ -299,6 +310,7 @@ class BlindRelayLink {
       this.stream = null
       unlink(this)
       this.session._links.delete(keyString)
+      this.session._server._untrackActiveLink(keyString)
       this.session._server.stats.streams.closed++
     }
 
@@ -306,6 +318,7 @@ class BlindRelayLink {
 
     this.session._pairing.delete(keyString)
     this.session._links.set(keyString, this)
+    this.session._server._trackActiveLink(keyString)
     this.session._server.stats.streams.opened++
   }
 
@@ -322,6 +335,7 @@ class BlindRelayLink {
     stream.off('error', this.session._onerror)
     unlink(this)
     this.session._links.delete(this.keyString)
+    this.session._server._untrackActiveLink(this.keyString)
     this.session._server.stats.streams.closed++
     stream.on('error', noop).destroy(err)
   }
@@ -541,57 +555,28 @@ function unlink(link) {
   }
 }
 
-function createStats(server) {
+function createStats() {
   const stats = {
     sessions: {
       accepted: 0,
       opened: 0,
-      closed: 0
+      closed: 0,
+      active: 0
     },
     pairings: {
       requested: 0,
       matched: 0,
-      cancelled: 0
+      cancelled: 0,
+      pending: 0,
+      active: 0
     },
     streams: {
       opened: 0,
       closed: 0,
-      errors: 0
+      errors: 0,
+      active: 0
     }
   }
-
-  Object.defineProperties(stats.sessions, {
-    active: {
-      enumerable: true,
-      get() {
-        return server._sessions.size
-      }
-    }
-  })
-
-  Object.defineProperties(stats.pairings, {
-    pending: {
-      enumerable: true,
-      get() {
-        return server._pairing.size
-      }
-    },
-    active: {
-      enumerable: true,
-      get() {
-        return server._activePairings()
-      }
-    }
-  })
-
-  Object.defineProperties(stats.streams, {
-    active: {
-      enumerable: true,
-      get() {
-        return server._activeStreams()
-      }
-    }
-  })
 
   return stats
 }

--- a/test.mjs
+++ b/test.mjs
@@ -247,6 +247,35 @@ test('stats: cancelled pending pairings', async (t) => {
   })
 })
 
+test('stats: session close cancels pending pairings', async (t) => {
+  const udx = new UDX()
+
+  let id = 0
+  const createStream = (opts) => udx.createStream(++id, opts)
+
+  const server = withServer(t, createStream)
+  const token = relay.token()
+  const { client, session } = withClient(t, server, { withSession: true })
+  const request = client.pair(true, token, createStream())
+
+  request.on('data', noop)
+  request.on('error', noop)
+
+  await waitFor(() => server.stats.pairings.pending === 1)
+
+  const closed = once(session, 'close')
+  client.destroy()
+  await closed
+
+  t.alike(server.stats.pairings, {
+    requested: 1,
+    matched: 0,
+    cancelled: 1,
+    pending: 0,
+    active: 0
+  })
+})
+
 test('stats: cancelled active pairings', async (t) => {
   const udx = new UDX()
 
@@ -289,6 +318,42 @@ test('stats: cancelled active pairings', async (t) => {
   t.is(server.stats.pairings.cancelled, 1)
   t.is(server.stats.pairings.active, 0)
   t.is(server.stats.streams.active, 0)
+})
+
+test('stats: active relay stream close updates gauges', async (t) => {
+  const udx = new UDX()
+
+  let id = 0
+  const createStream = (opts) => udx.createStream(++id, opts)
+
+  const server = withServer(t, createStream)
+  const token = relay.token()
+
+  const { client: clientA, session: sessionA } = withClient(t, server, {
+    withSession: true
+  })
+  const clientB = withClient(t, server)
+  const streamA = createStream()
+  const streamB = createStream()
+
+  const pairedOnServer = once(sessionA, 'pair')
+  const requestA = clientA.pair(true, token, streamA)
+  const requestB = clientB.pair(false, token, streamB)
+
+  await Promise.all([once(requestA, 'data'), once(requestB, 'data'), pairedOnServer])
+
+  const [, , relayStream] = await pairedOnServer
+
+  t.is(server.stats.pairings.active, 1)
+  t.is(server.stats.streams.active, 2)
+
+  relayStream.on('error', noop)
+  relayStream.destroy()
+
+  await waitFor(() => server.stats.streams.closed === 1)
+
+  t.is(server.stats.streams.active, 1)
+  t.is(server.stats.pairings.active, 1)
 })
 
 test('stats: stream errors', async (t) => {

--- a/test.mjs
+++ b/test.mjs
@@ -340,9 +340,12 @@ test('stats: active relay stream close updates gauges', async (t) => {
   const requestA = clientA.pair(true, token, streamA)
   const requestB = clientB.pair(false, token, streamB)
 
-  await Promise.all([once(requestA, 'data'), once(requestB, 'data'), pairedOnServer])
-
-  const [, , relayStream] = await pairedOnServer
+  const [, , serverPair] = await Promise.all([
+    once(requestA, 'data'),
+    once(requestB, 'data'),
+    pairedOnServer
+  ])
+  const [, , relayStream] = serverPair
 
   t.is(server.stats.pairings.active, 1)
   t.is(server.stats.streams.active, 2)
@@ -380,9 +383,12 @@ test('stats: stream errors', async (t) => {
   const requestA = clientA.pair(true, token, streamA)
   const requestB = clientB.pair(false, token, streamB)
 
-  await Promise.all([once(requestA, 'data'), once(requestB, 'data'), pairedOnServer])
-
-  const [, , relayStream] = await pairedOnServer
+  const [, , serverPair] = await Promise.all([
+    once(requestA, 'data'),
+    once(requestB, 'data'),
+    pairedOnServer
+  ])
+  const [, , relayStream] = serverPair
   const err = new Error('boom')
 
   relayStream.emit('error', err)

--- a/test.mjs
+++ b/test.mjs
@@ -383,12 +383,9 @@ test('stats: stream errors', async (t) => {
   const requestA = clientA.pair(true, token, streamA)
   const requestB = clientB.pair(false, token, streamB)
 
-  const [, , serverPair] = await Promise.all([
-    once(requestA, 'data'),
-    once(requestB, 'data'),
-    pairedOnServer
-  ])
-  const [, , relayStream] = serverPair
+  await Promise.all([once(requestA, 'data'), once(requestB, 'data')])
+
+  const [, , relayStream] = await pairedOnServer
   const err = new Error('boom')
 
   relayStream.emit('error', err)


### PR DESCRIPTION
This changes relay stats from computed getters into maintained numeric counters, so metric reads are O(1).

I also added coverage for cleanup paths that are easy to miss with maintained counters: pending pairings cancelled by session close, and active relay streams closing directly.

This PR was co-written with AI