### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "b4a": "^1.6.4",
     "bare-events": "^2.2.0",
     "bits-to-bytes": "^1.3.0",
-    "compact-encoding": "^2.12.0",
+    "compact-encoding": "^3.0.0",
     "compact-encoding-bitfield": "^1.0.0",
     "protomux": "^3.5.1",
     "sodium-universal": "^5.0.0",


### PR DESCRIPTION
Depends on:

- https://github.com/holepunchto/protomux/pull/28
- https://github.com/holepunchto/compact-encoding-bitfield/pull/4