### PR TITLE
Fix active pair teardown on session close

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,8 +139,8 @@ class BlindRelaySession extends EventEmitter {
       }
     }
 
-    for (const link of this._links.values()) {
-      link.destroy(err)
+    for (const link of [...this._links.values()]) {
+      link.destroyPair(err)
     }
 
     this._pairing.clear()

--- a/test.mjs
+++ b/test.mjs
@@ -276,6 +276,40 @@ test('stats: session close cancels pending pairings', async (t) => {
   })
 })
 
+test('stats: session close tears down both active relay streams', async (t) => {
+  const udx = new UDX()
+
+  let id = 0
+  const createStream = (opts) => udx.createStream(++id, opts)
+
+  const server = withServer(t, createStream)
+  const token = relay.token()
+
+  const { client: clientA, session: sessionA } = withClient(t, server, {
+    withSession: true
+  })
+  const clientB = withClient(t, server)
+  const streamA = createStream()
+  const streamB = createStream()
+
+  const requestA = clientA.pair(true, token, streamA)
+  const requestB = clientB.pair(false, token, streamB)
+
+  await Promise.all([once(requestA, 'data'), once(requestB, 'data')])
+
+  t.is(server.stats.pairings.active, 1)
+  t.is(server.stats.streams.active, 2)
+
+  const closed = once(sessionA, 'close')
+  clientA.destroy()
+  await closed
+
+  await waitFor(() => server.stats.streams.closed === 2)
+
+  t.is(server.stats.pairings.active, 0)
+  t.is(server.stats.streams.active, 0)
+})
+
 test('stats: cancelled active pairings', async (t) => {
   const udx = new UDX()
 


### PR DESCRIPTION
Previously, session close destroyed only that session’s relay link. The paired remote link could remain active until the other peer also closed, leaving stale active stream/pairing state.

This now uses the existing pair-aware teardown path, `destroyPair()`, for active links on session close.

`destroyPair()` was introduced in [#12](https://github.com/holepunchto/blind-relay/pull/12) to fix one-sided active `unpair` cleanup.  That PR fixed the explicit unpair leak, but left the equivalent session-close path which also could benifit from a stricter cleanup behaviour.