### PR TITLE
Add `basic - slow connection` test

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "brittle": "^3.2.1",
+    "debugging-stream": "^3.1.0",
     "hyperdht": "^6.6.1",
     "lunte": "^1.0.0",
     "prettier": "^3.6.2",

--- a/test.mjs
+++ b/test.mjs
@@ -64,6 +64,68 @@ test('basic', (t) => {
   }
 })
 
+test('basic - slow connection', (t) => {
+  t.plan(8)
+
+  const udx = new UDX()
+  const socket = withSocket(t, udx)
+
+  let id = 0
+  const createStream = (opts) => udx.createStream(++id, opts)
+
+  const server = withServer(t, createStream)
+  const token = relay.token()
+
+  const latency = 500
+  const jitter = 100
+
+  {
+    const client = withClient(t, server, { debugging: { latency, jitter } })
+    const stream = createStream()
+
+    client.on('pair', (...args) => t.alike(args, [true, token, stream, 4]))
+
+    const request = client.pair(true, token, stream)
+
+    request
+      .on('error', (err) => t.fail(err))
+      .on('data', (remoteId) => {
+        t.pass(`paired with ${remoteId}`)
+
+        request.stream
+          .on('error', () => {})
+          .on('close', () => t.pass('stream closed'))
+          .on('data', (data) => t.alike(data.toString(), 'initiatee'))
+          .connect(socket, remoteId, socket.address().port)
+
+        request.stream.end('initiator')
+      })
+  }
+
+  {
+    const client = withClient(t, server, { debugging: { latency, jitter } })
+    const stream = createStream()
+
+    client.on('pair', (...args) => t.alike(args, [false, token, stream, 3]))
+
+    const request = client.pair(false, token, stream)
+
+    request
+      .on('error', (err) => t.fail(err))
+      .on('data', (remoteId) => {
+        t.pass(`paired with ${remoteId}`)
+
+        request.stream
+          .on('error', () => {})
+          .on('close', () => t.pass('stream closed'))
+          .on('data', (data) => t.alike(data.toString(), 'initiator'))
+          .connect(socket, remoteId, socket.address().port)
+
+        request.stream.end('initiatee')
+      })
+  }
+})
+
 test('both peers can unpair after pairing', (t) => {
   t.plan(2)
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,6 @@
 const { Duplex } = require('streamx')
 const relay = require('..')
+const DebuggingStream = require('debugging-stream')
 
 exports.withSocket = function withSocket(t, udx) {
   const socket = udx.createSocket()
@@ -17,20 +18,24 @@ exports.withServer = function withServer(t, createStream) {
 exports.withClient = function withClient(t, server, opts = {}) {
   const { onerror = (err) => t.fail(err), withSession = false } = opts
 
-  const serverStream = new Duplex({
+  let serverStream = new Duplex({
     write(data, cb) {
       clientStream.push(data)
       cb(null)
     }
   })
 
-  const clientStream = new Duplex({
+  let clientStream = new Duplex({
     write(data, cb) {
       serverStream.push(data)
       cb(null)
     }
   })
 
+  if (opts.debugging) {
+    serverStream = new DebuggingStream(serverStream, opts.debugging)
+    clientStream = new DebuggingStream(clientStream, opts.debugging)
+  }
   const session = server.accept(serverStream)
   session.on('error', onerror)
 


### PR DESCRIPTION
A test with artificial latency seems to hit the flake more often. Latency, speed & jitter are customizable now via `withClient` which applies the settings passed via the `opts.debugging` option equally to both the server side and the client side streams.